### PR TITLE
Add GET /ingredients endpoint with 200/404/500 handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -37,6 +37,29 @@ app.get('/api/temp', async (req, res) => {
   res.json(data);
 });
 
+app.get('/ingredients', async (req, res) => {
+  if (!supabase) {
+    return res.status(500).json({
+      error:
+        'Supabase is not configured. Set SUPABASE_URL and SUPABASE_SECRET_KEY in .env',
+    });
+  }
+
+  const { data, error } = await supabase
+    .from('ingredients')
+    .select('id, name, image, substitutes');
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  if (!data || data.length === 0) {
+    return res.status(404).json({ error: 'No ingredients found' });
+  }
+
+  return res.status(200).json(data);
+});
+
 app.listen(PORT, () => {
   console.log(`Example app listening on port ${PORT}`);
 });


### PR DESCRIPTION
Added Get /ingredients in server.js.
Returns 200 with id, name, image, substitutes or 404 when none found, 500 on server/db error. 